### PR TITLE
Updated the deploy job 

### DIFF
--- a/.github/workflows/cd.prod.yaml
+++ b/.github/workflows/cd.prod.yaml
@@ -4,6 +4,7 @@ on:
     branches: [main]
 jobs:
   deploy:
+    if: github.event.pull_request == null
     name: deploy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Updated the deploy job:
Added if: github.event.pull_request == null to the deploy job

This condition checks if the push event was triggered by a direct push rather than a PR merge
When a PR is merged, the pull_request context will be present

This way:

Direct pushes to main ✅ Will trigger deployment
PR merges to main ❌ Won't trigger deployment
Pushes to other branches ❌ Won't trigger deployment